### PR TITLE
feat: refresh expired access token on connect

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -1,2 +1,15 @@
-export {}
-console.log("HELLO WORLD FROM BGSCRIPTS")
+import { Storage } from "@plasmohq/storage"
+
+import type { Session } from "~types/session"
+import { refreshTokens } from "~services/auth"
+
+const storage = new Storage({ area: 'local' })
+
+chrome.runtime.onConnect.addListener(async () => {
+    const session = await storage.get('session') as Session
+
+    if (!session?.expires_at) return
+    if (session.expires_at >= Date.now()) return 
+
+    await refreshTokens(session.refresh_token)
+})


### PR DESCRIPTION
On connect, i.e click on extension icon in toolbar, refresh access toke, if current time (Date.now()) is greater than session `expires_at` value.

closes #7 